### PR TITLE
Feature/9 react router data loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-dom": "18.1.0",
     "react-i18next": "11.17.1",
     "react-redux": "8.0.2",
-    "react-router-dom": "6",
+    "react-router-dom": "^6.4.5",
     "react-scripts": "5.0.1",
     "react-spring": "9.4.5",
     "reflect-metadata": "0.1.13",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,6 @@
 import React, { StrictMode } from "react";
 import reportWebVitals from "./reportWebVitals";
 import { createRoot } from "react-dom/client";
-import { unstable_HistoryRouter as HistoryRouter } from "react-router-dom";
-import { createBrowserHistory } from "history";
 import { Provider } from "react-redux";
 import App from "@/src/ui/app";
 import { store } from "@/src/ui/state";
@@ -25,18 +23,15 @@ if (locator.get<IEnvVars>(TYPES.IEnvVars).sentryEnabled) {
 
 const container = document.getElementById("root");
 const root = createRoot(container as HTMLElement);
-const history = createBrowserHistory({ window });
 if (window.Cypress) {
   window.tgHistory = history;
 }
 root.render(
   // Un comment strict mode when libraries like redux and react spring support react 18v in a stable way
   <StrictMode>
-    <HistoryRouter history={history}>
-      <Provider store={store}>
-        <App />
-      </Provider>
-    </HistoryRouter>
+    <Provider store={store}>
+      <App />
+    </Provider>
   </StrictMode>
 );
 

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -1,18 +1,17 @@
 import { GlobalStyles } from "@/src/ui/styles/globals";
 import { Modal } from "@/src/ui/components/modal/modal";
 import { MainLoader } from "@/src/ui/components/main_loader/main_loader";
-import { useRoutes } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { routes } from "@/src/ui/router/routes";
 
+const router = createBrowserRouter(routes);
 function App() {
-  const page = useRoutes(routes);
-
   return (
     <>
       <GlobalStyles />
       <Modal />
       <MainLoader />
-      {page}
+      <RouterProvider router={router} />
     </>
   );
 }

--- a/src/ui/components/base_layout/base_layout.tsx
+++ b/src/ui/components/base_layout/base_layout.tsx
@@ -29,6 +29,9 @@ export const BaseLayout = () => {
           <li>
             <Link to="/posts">list post</Link>
           </li>
+          <li>
+            <Link to="/posts-react-router">list post (react router)</Link>
+          </li>
         </ul>
         <Button data-cy="login-btn" onClick={logUser}>
           {userLogged ? "Log out" : "Log in"}

--- a/src/ui/pages/posts_react_router/components/posts_react_router_page/posts_react_router_page.loader.ts
+++ b/src/ui/pages/posts_react_router/components/posts_react_router_page/posts_react_router_page.loader.ts
@@ -1,0 +1,14 @@
+import { defer } from "react-router-dom";
+import { locator } from "@/src/core/app/ioc";
+import type { IocProvider } from "@/src/core/app/ioc/interfaces";
+import type { GetDummyPostsUseCase } from "@/src/core/dummy/domain/use_cases/get_dummy_posts_use_case";
+import { TYPES } from "@/src/core/app/ioc/types";
+
+export function postsPageLoader() {
+  return defer({
+    posts: (async () => {
+      const getDummyPostsUseCase = await locator.get<IocProvider<GetDummyPostsUseCase>>(TYPES.GetDummyPostsUseCase)();
+      return await getDummyPostsUseCase.execute();
+    })()
+  });
+}

--- a/src/ui/pages/posts_react_router/components/posts_react_router_page/posts_react_router_page.tsx
+++ b/src/ui/pages/posts_react_router/components/posts_react_router_page/posts_react_router_page.tsx
@@ -1,0 +1,27 @@
+import Styled from "@/src/ui/pages/dummy/components/dummy_page/dummy_page.styled";
+import { useBreakpointsMatch } from "@front_web_mrmilu/hooks";
+import { Suspense } from "react";
+import { Await, useLoaderData } from "react-router-dom";
+import type { DummyPost } from "@/src/core/dummy/domain/models/dummy_post";
+
+export default function PostsReactRouterPage() {
+  const { mdAndUp } = useBreakpointsMatch();
+  const { posts } = useLoaderData() as { posts: DummyPost[] };
+  return (
+    <Styled.Wrapper data-cy="posts-page">
+      {mdAndUp && <h2>Posts page</h2>}
+
+      <Suspense fallback="Loading posts…">
+        <Await resolve={posts} errorElement="Error loading posts">
+          {(posts: DummyPost[]) => (
+            <>
+              {posts.map((post, idx) => (
+                <Styled.SimpleCard data-cy="dummy-card" key={`${post.id}_${idx}`} title={post.title} subtitle={post.body} />
+              ))}
+            </>
+          )}
+        </Await>
+      </Suspense>
+    </Styled.Wrapper>
+  );
+}

--- a/src/ui/router/routes.tsx
+++ b/src/ui/router/routes.tsx
@@ -6,10 +6,12 @@ import { lazy } from "react";
 import { SuspenseMainLoader } from "@/src/ui/components/suspense_main_loader/suspense_main_loader";
 import { RouteMiddleware } from "@/src/ui/router/route_middleware";
 import { useAuthMiddleware } from "@/src/ui/router/middlewares/auth_middleware.hook";
+import { postsPageLoader } from "@/src/ui/pages/posts_react_router/components/posts_react_router_page/posts_react_router_page.loader";
 
 const HomePage = lazy(() => import("@/src/ui/pages/home/components/home_page/home_page"));
 const DummyPage = lazy(() => import("@/src/ui/pages/dummy/components/dummy_page/dummy_page"));
 const PostsPage = lazy(() => import("@/src/ui/pages/dummy/components/posts_page/posts_page"));
+const PostsReactRouterPage = lazy(() => import("@/src/ui/pages/posts_react_router/components/posts_react_router_page/posts_react_router_page"));
 const CreatePostPage = lazy(() => import("@/src/ui/pages/dummy/components/create_post_page/create_post_page"));
 
 export const routes: Array<RouteObject> = [
@@ -42,6 +44,15 @@ export const routes: Array<RouteObject> = [
         element: (
           <SuspenseMainLoader>
             <PostsPage />
+          </SuspenseMainLoader>
+        )
+      },
+      {
+        path: "/posts-react-router",
+        loader: postsPageLoader,
+        element: (
+          <SuspenseMainLoader>
+            <PostsReactRouterPage />
           </SuspenseMainLoader>
         )
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,7 +1514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.18.3
   resolution: "@babel/runtime@npm:7.18.3"
   dependencies:
@@ -3280,6 +3280,13 @@ __metadata:
     react-redux:
       optional: true
   checksum: bd94e6d5c469f841c59e7d74e3fc60681c023ccdc6367005a9b04c252990d103bba438b2aea82f6e3db697486b32f4a5fb0d4bb6208af6119e5028c2ee626198
+  languageName: node
+  linkType: hard
+
+"@remix-run/router@npm:1.0.5":
+  version: 1.0.5
+  resolution: "@remix-run/router@npm:1.0.5"
+  checksum: 5d66750b7defc10c80d9748fa003fcfe2af9ef82de3c06be88c926ede36a15b9e971ed2222981db843494e2f77c3de14470efe6dc877530cea774dc31162ec6f
   languageName: node
   linkType: hard
 
@@ -9494,15 +9501,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"history@npm:^5.2.0":
-  version: 5.3.0
-  resolution: "history@npm:5.3.0"
-  dependencies:
-    "@babel/runtime": ^7.7.6
-  checksum: d73c35df49d19ac172f9547d30a21a26793e83f16a78386d99583b5bf1429cc980799fcf1827eb215d31816a6600684fba9686ce78104e23bd89ec239e7c726f
-  languageName: node
-  linkType: hard
-
 "hoist-non-react-statics@npm:^3.0.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
@@ -14470,27 +14468,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:6":
-  version: 6.3.0
-  resolution: "react-router-dom@npm:6.3.0"
+"react-router-dom@npm:^6.4.5":
+  version: 6.4.5
+  resolution: "react-router-dom@npm:6.4.5"
   dependencies:
-    history: ^5.2.0
-    react-router: 6.3.0
+    "@remix-run/router": 1.0.5
+    react-router: 6.4.5
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 77603a654f8a8dc7f65535a2e5917a65f8d9ffcb06546d28dd297e52adcc4b8a84377e0115f48dca330b080af2da3e78f29d590c89307094d36927d2b1751ec3
+  checksum: 09d7841dd52efd2c60947171f95d9d1860cabd7540ac74dede86a6c36a2dd26a645e4928cbc8aa4e1c9d1f906f2ef144ba6da5ac69243590df855a6df8cfe1aa
   languageName: node
   linkType: hard
 
-"react-router@npm:6.3.0":
-  version: 6.3.0
-  resolution: "react-router@npm:6.3.0"
+"react-router@npm:6.4.5":
+  version: 6.4.5
+  resolution: "react-router@npm:6.4.5"
   dependencies:
-    history: ^5.2.0
+    "@remix-run/router": 1.0.5
   peerDependencies:
     react: ">=16.8"
-  checksum: 7be673f5e72104be01e6ab274516bdb932efd93305243170690f6560e3bd1035dd1df3d3c9ce1e0f452638a2529f43a1e77dcf0934fc8031c4783da657be13ca
+  checksum: 0d471df39f0487224240f9910c2f2939519f3e9909a7b19f72767aeea2caf1c9fa4e8ea9a51b17c20051ec252db0fcc34a7a0b3068b338dd9d8eb656ffd489c1
   languageName: node
   linkType: hard
 
@@ -14645,7 +14643,7 @@ __metadata:
     react-dom: 18.1.0
     react-i18next: 11.17.1
     react-redux: 8.0.2
-    react-router-dom: 6
+    react-router-dom: ^6.4.5
     react-scripts: 5.0.1
     react-spring: 9.4.5
     reflect-metadata: 0.1.13


### PR DESCRIPTION
Closes #9 
Data loading with React Router example.

Substituting Redux with React Router for data loading has the advantage of simplifying the logic of the app. However, I can see a few disadvantages:

- The data fetching hooks and components like useLoaderData and Await do not have any TypeScript integration. Not even generics. The only way to type the return value is to use the `as` operator. 
- A loader is always shown when you enter the page, even if it is the second time you enter it.
- The aim of the repo mantainers is not to substitute data fetching libraries like React Query, but to work in combination with them. As mentioned in the guide: (https://reactrouter.com/en/main/guides/data-libs)

> Use React Router for timing of data loading, mutations, and navigation state, then use libraries like React Query for the actual implementation of loading, invalidating, storage, and caching.

Maybe this is the reason why the TypeScript integration is so poor. The maintainers want to encourage you to use React Query to store the loaded data.

In my opinion, a solution would be to combine React Router data fetching with Zustand. Inside the React Router loader, you call the Zustand function that loads the data, and store it inside the Zustand store. And the data is then accessed in the component with the Zustand hooks. This way, you don't have to use useEffect to fetch the data. Instead, you fetch the data inside the React Router loader.